### PR TITLE
Daemon not json requests (python examples)

### DIFF
--- a/content/en/daemon/not_json/get_alt_blocks_hashes.md
+++ b/content/en/daemon/not_json/get_alt_blocks_hashes.md
@@ -8,6 +8,11 @@ weight: 305
 ```shell
 $ curl -X POST http://127.0.0.1:18081/get_alt_blocks_hashes -H 'Content-Type: application/json'
 ```
+```python
+  ...^ see introduction
+  url = "http://127.0.0.1:18081/get_alt_blocks_hashes"
+  ...^ see introduction
+```
 ```json
 {
   "blks_hashes": ["9c2277c5470234be8b32382cdf8094a103aba4fcd5e875a6fc159dc2ec00e011","637c0e0f0558e284493f38a5fcca3615db59458d90d3a5eff0a18ff59b83f46f","6f3adc174a2e8082819ebb965c96a095e3e8b63929ad9be2d705ad9c086a6b1c","697cf03c89a9b118f7bdf11b1b3a6a028d7b3617d2d0ed91322c5709acf75625","d99b3cf3ac6f17157ac7526782a3c3b9537f89d07e069f9ce7821d74bd9cad0e","e97b62109a6303233dcd697fa8545c9fcbc0bf8ed2268fede57ddfc36d8c939c","70ff822066a53ad64b04885c89bbe5ce3e537cdc1f7fa0dc55317986f01d1788","b0d36b209bd0d4442b55ea2f66b5c633f522401f921f5a85ea6f113fd2988866"],

--- a/content/en/daemon/not_json/get_height.md
+++ b/content/en/daemon/not_json/get_height.md
@@ -7,6 +7,11 @@ weight: 305
 ```shell
 $ curl -X POST http://127.0.0.1:18081/get_height -H 'Content-Type: application/json'
 ```
+```python
+  ...^ see introduction
+  url = "http://127.0.0.1:18081/get_height"
+  ...^ see introduction
+```
 ```json
 {
   "height": 1564055,

--- a/content/en/daemon/not_json/get_info.md
+++ b/content/en/daemon/not_json/get_info.md
@@ -15,6 +15,11 @@ Alias:
 ```shell
 $ curl -X POST http://127.0.0.1:18081/get_limit -H 'Content-Type: application/json'
 ```
+```python
+  ...^ see introduction
+  url = "http://127.0.0.1:18081/get_limit"
+  ...^ see introduction
+```
 ```json
 {
   "limit_down": 8192,

--- a/content/en/daemon/not_json/get_peer_list.md
+++ b/content/en/daemon/not_json/get_peer_list.md
@@ -9,6 +9,11 @@ weight: 305
 ```shell
 $ curl -X POST http://127.0.0.1:18081/get_peer_list -H 'Content-Type: application/json'
 ```
+```python
+  ...^ see introduction
+  url = "http://127.0.0.1:18081/get_peer_list"
+  ...^ see introduction
+```
 ```json
 {
   "gray_list": [{

--- a/content/en/daemon/not_json/get_transaction_pool.md
+++ b/content/en/daemon/not_json/get_transaction_pool.md
@@ -9,6 +9,11 @@ weight: 305
 ```shell
 $ curl -X POST http://127.0.0.1:18081/get_transaction_pool -H 'Content-Type: application/json'
 ```
+```python
+  ...^ see introduction
+  url = "http://127.0.0.1:18081/get_transaction_pool"
+  ...^ see introduction
+```
 ```json
 {
   "spent_key_images": [{

--- a/content/en/daemon/not_json/get_transaction_pool_stats.md
+++ b/content/en/daemon/not_json/get_transaction_pool_stats.md
@@ -7,6 +7,11 @@ weight: 305
 ```shell
 $ curl -X POST http://127.0.0.1:18081/get_transaction_pool_stats -H 'Content-Type: application/json'
 ```
+```python
+  ...^ see introduction
+  url = "http://127.0.0.1:18081/get_transaction_pool_stats"
+  ...^ see introduction
+```
 ```json
 {
   "pool_stats": {

--- a/content/en/daemon/not_json/get_transactions.md
+++ b/content/en/daemon/not_json/get_transactions.md
@@ -9,6 +9,16 @@ weight: 305
 ```shell
 $ curl -X POST http://127.0.0.1:18081/get_transactions -d '{"txs_hashes":["d6e48158472848e6687173a91ae6eebfa3e1d778e65252ee99d7515d63090408"]}' -H 'Content-Type: application/json'
 ```
+```python
+  ...^ see introduction
+  url = "http://127.0.0.1:18081/get_transactions"
+  data = {
+      "txs_hashes": [
+          "d6e48158472848e6687173a91ae6eebfa3e1d778e65252ee99d7515d63090408"
+      ]
+  }
+  ...^ see introduction
+```
 ```json
 {
   "status": "OK",

--- a/content/en/daemon/not_json/in_peers.md
+++ b/content/en/daemon/not_json/in_peers.md
@@ -7,6 +7,12 @@ weight: 305
 ```shell
 $ curl -X POST http://127.0.0.1:18081/out_peers -d '{"in_peers": 3232235535}' -H 'Content-Type: application/json'
 ```
+```python
+  ...^ see introduction
+  url = "http://127.0.0.1:18081/out_peers"
+  data = {"in_peers": 3232235535}
+  ...^ see introduction
+```
 ```json
 {
   "status": "OK"

--- a/content/en/daemon/not_json/introduction_other_daemon_rpc.md
+++ b/content/en/daemon/not_json/introduction_other_daemon_rpc.md
@@ -8,6 +8,7 @@ title: Wallet RPC API Reference
   This part is the same for all methods and described just here.
   For each request you need define first this:
       import requests
+      import json
       header = {"Content-Type": "application/json"}
 
   This part is different for all method and described below for each method.
@@ -17,7 +18,7 @@ title: Wallet RPC API Reference
 
   This part is the same for all methods and described just here.
   For each request you get response like this:
-      response = requests.post(url, headers=header)
+      response = requests.post(url, data=json.dumps(data), headers=header)
       response.raise_for_status()
       response.json()
 ```

--- a/content/en/daemon/not_json/introduction_other_daemon_rpc.md
+++ b/content/en/daemon/not_json/introduction_other_daemon_rpc.md
@@ -8,12 +8,12 @@ title: Wallet RPC API Reference
   This part is the same for all methods and described just here.
   For each request you need define first this:
       import requests
-      import json
       header = {"Content-Type": "application/json"}
 
   This part is different for all method and described below for each method.
   In data struct you set params for request, example:
-      url = "http://127.0.0.1:18082/get_height"
+      url = "http://127.0.0.1:18081/set_limit"
+      data = {"limit_down": 1024}
 
   This part is the same for all methods and described just here.
   For each request you get response like this:

--- a/content/en/daemon/not_json/introduction_other_daemon_rpc.md
+++ b/content/en/daemon/not_json/introduction_other_daemon_rpc.md
@@ -4,7 +4,23 @@ title: Wallet RPC API Reference
 ---
 
 # Other Daemon RPC Calls
+```python
+  This part is the same for all methods and described just here.
+  For each request you need define first this:
+      import requests
+      import json
+      header = {"Content-Type": "application/json"}
 
+  This part is different for all method and described below for each method.
+  In data struct you set params for request, example:
+      url = "http://127.0.0.1:18082/get_height"
+
+  This part is the same for all methods and described just here.
+  For each request you get response like this:
+      response = requests.post(url, headers=header)
+      response.raise_for_status()
+      response.json()
+```
 Not all daemon RPC calls use the JSON_RPC interface. This section gives examples of these calls.
 
 The data structure for these calls is different than the JSON RPC calls. Whereas the JSON RPC methods were called using the `/json_rpc` extension and specifying a method, these methods are called at their own extensions. For example:  

--- a/content/en/daemon/not_json/is_key_image_spent.md
+++ b/content/en/daemon/not_json/is_key_image_spent.md
@@ -7,6 +7,17 @@ weight: 305
 ```shell
 $ curl -X POST http://127.0.0.1:18081/is_key_image_spent -d '{"key_images":["8d1bd8181bf7d857bdb281e0153d84cd55a3fcaa57c3e570f4a49f935850b5e3","7319134bfc50668251f5b899c66b005805ee255c136f0e1cecbb0f3a912e09d4"]}' -H 'Content-Type: application/json'
 ```
+```python
+  ...^ see introduction
+  url = "http://127.0.0.1:18081/is_key_image_spent"
+  data = {
+      "key_images": [
+          "8d1bd8181bf7d857bdb281e0153d84cd55a3fcaa57c3e570f4a49f935850b5e3",
+          "7319134bfc50668251f5b899c66b005805ee255c136f0e1cecbb0f3a912e09d4",
+      ]
+  }
+  ...^ see introduction
+```
 ```json
 {
   "spent_status": [1,2],

--- a/content/en/daemon/not_json/mining_status.md
+++ b/content/en/daemon/not_json/mining_status.md
@@ -9,6 +9,11 @@ weight: 305
 ```shell
 $ curl -X POST http://127.0.0.1:18081/mining_status -H 'Content-Type: application/json'
 ```
+```python
+  ...^ see introduction
+  url = "http://127.0.0.1:18081/mining_status"
+  ...^ see introduction
+```
 ```json
 {
   "active": true,

--- a/content/en/daemon/not_json/out_peers.md
+++ b/content/en/daemon/not_json/out_peers.md
@@ -7,6 +7,12 @@ weight: 305
 ```shell
 $ curl -X POST http://127.0.0.1:18081/out_peers -d '{"out_peers": 3232235535}' -H 'Content-Type: application/json'
 ```
+```python
+  ...^ see introduction
+  url = "http://127.0.0.1:18081/out_peers"
+  data = {"out_peers": 3232235535}
+  ...^ see introduction
+```
 ```json
 {
   "status": "OK"

--- a/content/en/daemon/not_json/save_bc.md
+++ b/content/en/daemon/not_json/save_bc.md
@@ -7,6 +7,11 @@ weight: 305
 ```shell
 $ curl -X POST http://127.0.0.1:18081/save_bc -H 'Content-Type: application/json'
 ```
+```python
+  ...^ see introduction
+  url = "http://127.0.0.1:18081/save_bc"
+  ...^ see introduction
+```
 ```json
 {
   "status": "OK"

--- a/content/en/daemon/not_json/send_raw_transaction.md
+++ b/content/en/daemon/not_json/send_raw_transaction.md
@@ -9,6 +9,12 @@ weight: 305
 ```shell
 $ curl -X POST http://127.0.0.1:18081/send_raw_transaction -d '{"tx_as_hex":"de6a3...", "do_not_relay":false}' -H 'Content-Type: application/json'
 ```
+```python
+  ...^ see introduction
+  url = "http://127.0.0.1:18081/send_raw_transaction"
+  data = {"tx_as_hex": "de6a3...", "do_not_relay": False}
+  ...^ see introduction
+```
 
 Broadcast a raw transaction to the network.  
 Alias: **/sendrawtransaction**.  

--- a/content/en/daemon/not_json/set_limit.md
+++ b/content/en/daemon/not_json/set_limit.md
@@ -7,6 +7,12 @@ weight: 305
 ```shell
 $ curl -X POST http://127.0.0.1:18081/set_limit -d '{"limit_down": 1024}' -H 'Content-Type: application/json'
 ```
+```python
+  ...^ see introduction
+  url = "http://127.0.0.1:18081/set_limit"
+  data = {"limit_down": 1024}
+  ...^ see introduction
+```
 ```json
 {
   "limit_down": 1024,

--- a/content/en/daemon/not_json/set_log_categories.md
+++ b/content/en/daemon/not_json/set_log_categories.md
@@ -9,6 +9,12 @@ weight: 305
 ```shell
 $ curl -X POST http://127.0.0.1:18081/set_log_categories -d '{"categories": "*:INFO"}' -H 'Content-Type: application/json'
 ```
+```python
+  ...^ see introduction
+  url = "http://127.0.0.1:18081/set_log_categories"
+  data = {"categories": "*:INFO"}
+  ...^ see introduction
+```
 ```json
 {
   "categories": "*:INFO",

--- a/content/en/daemon/not_json/set_log_hash_rate.md
+++ b/content/en/daemon/not_json/set_log_hash_rate.md
@@ -9,6 +9,12 @@ weight: 305
 ```shel
 $ curl -X POST http://127.0.0.1:18081/set_log_hash_rate -d '{"visible":true}' -H 'Content-Type: application/json'
 ```
+```python
+  ...^ see introduction
+  url = "http://127.0.0.1:18081/set_log_hash_rate"
+  data = {"visible": True}
+  ...^ see introduction
+```
 ```json
 {
   "status": "OK"

--- a/content/en/daemon/not_json/set_log_level.md
+++ b/content/en/daemon/not_json/set_log_level.md
@@ -7,6 +7,12 @@ weight: 305
 ```shell
 $ curl -X POST http://127.0.0.1:18081/set_log_level -d '{"level":1}' -H 'Content-Type: application/json'
 ```
+```python
+  ...^ see introduction
+  url = "http://127.0.0.1:18081/set_log_level"
+  data = {"level": 1}
+  ...^ see introduction
+```
 ```json
 {
   "status": "OK"

--- a/content/en/daemon/not_json/start_mining.md
+++ b/content/en/daemon/not_json/start_mining.md
@@ -7,6 +7,17 @@ weight: 305
 ```shell
 $ curl -X POST http://127.0.0.1:18081/start_mining -d '{"do_background_mining":false,"ignore_battery":true,"miner_address":"47xu3gQpF569au9C2ajo5SSMrWji6xnoE5vhr94EzFRaKAGw6hEGFXYAwVADKuRpzsjiU1PtmaVgcjUJF89ghGPhUXkndHc","threads_count":1}' -H 'Content-Type: application/json'
 ```
+```python
+  ...^ see introduction
+  url = "http://127.0.0.1:18081/start_mining"
+  data = {
+      "do_background_mining": False,
+      "ignore_battery": True,
+      "miner_address": "47xu3gQpF569au9C2ajo5SSMrWji6xnoE5vhr94EzFRaKAGw6hEGFXYAwVADKuRpzsjiU1PtmaVgcjUJF89ghGPhUXkndHc",
+      "threads_count": 1,
+  }
+  ...^ see introduction
+```
 ```json
 {
   "status": "OK"

--- a/content/en/daemon/not_json/start_save_graph.md
+++ b/content/en/daemon/not_json/start_save_graph.md
@@ -7,6 +7,11 @@ weight: 305
 ```shell
 $ curl -X POST http://127.0.0.1:18081/start_save_graph -H 'Content-Type: application/json'
 ```
+```python
+  ...^ see introduction
+  url = "http://127.0.0.1:18081/start_save_graph"
+  ...^ see introduction
+```
 ```json
 {
   "status": "OK"

--- a/content/en/daemon/not_json/stop_daemon.md
+++ b/content/en/daemon/not_json/stop_daemon.md
@@ -7,6 +7,11 @@ weight: 305
 ```shell
 $ curl -X POST http://127.0.0.1:18081/stop_daemon -H 'Content-Type: application/json'
 ```
+```python
+  ...^ see introduction
+  url = "http://127.0.0.1:18081/stop_daemon"
+  ...^ see introduction
+```
 ```json
 {
   "status": "OK"

--- a/content/en/daemon/not_json/stop_mining.md
+++ b/content/en/daemon/not_json/stop_mining.md
@@ -7,6 +7,11 @@ weight: 305
 ```shell
 $ curl -X POST http://127.0.0.1:18081/stop_mining -H 'Content-Type: application/json'
 ```
+```python
+  ...^ see introduction
+  url = "http://127.0.0.1:18081/stop_mining"
+  ...^ see introduction
+```
 ```json
 {
   "status": "OK"

--- a/content/en/daemon/not_json/stop_save_graph.md
+++ b/content/en/daemon/not_json/stop_save_graph.md
@@ -7,6 +7,11 @@ weight: 305
 ```shell
 $ curl -X POST http://127.0.0.1:18081/stop_save_graph -H 'Content-Type: application/json'
 ```
+```python
+  ...^ see introduction
+  url = "http://127.0.0.1:18081/stop_save_graph"
+  ...^ see introduction
+```
 ```json
 {
   "status": "OK"

--- a/content/en/daemon/not_json/update.md
+++ b/content/en/daemon/not_json/update.md
@@ -7,6 +7,12 @@ weight: 305
 ```shell
 $ curl -X POST http://127.0.0.1:18081/update -d '{"command":"check"}' -H 'Content-Type: application/json'
 ```
+```python
+  ...^ see introduction
+  url = "http://127.0.0.1:18081/update"
+  data = {"command": "check"}
+  ...^ see introduction
+```
 ```json
 {
   "auto_uri": "",


### PR DESCRIPTION
Python examples for deamon not json requests, represented by requests library only, because python-monerorpc doesn't communicate with the daemon in this way. I also skipped examples for bin requests, because they always return 404 code